### PR TITLE
Preserve Traceback in stdoutput on failure

### DIFF
--- a/sbin/run.ps1
+++ b/sbin/run.ps1
@@ -84,7 +84,6 @@ while ($true) {
             if ($l -match "^(OK|FAILED|ERROR)") {
                 $done = $matches[1]
                 write-output $l
-                break
             }
         }
         $read = $read + $count - 1


### PR DESCRIPTION
Simplify troubleshooting.

Before:

![image](https://cloud.githubusercontent.com/assets/816680/5797871/f4b918de-9f75-11e4-8f1d-24cefe12aa2b.png)

After:

![image](https://cloud.githubusercontent.com/assets/816680/5797886/1755b97e-9f76-11e4-950a-816c42f82beb.png)
